### PR TITLE
feat: Implement Compass View for POI direction

### DIFF
--- a/client/src/components/Navigation/CompassView.tsx
+++ b/client/src/components/Navigation/CompassView.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, NavigationArrow } from 'lucide-react';
+import { POI } from '@/types/poi-categories';
+import { useLocation } from '@/hooks/useLocation';
+import { useDeviceOrientation } from '@/hooks/useDeviceOrientation';
+import { calculateBearing, calculateDistance, formatDistance } from '@/lib/mapUtils';
+import { cn } from '@/lib/utils';
+
+interface CompassViewProps {
+  destination: POI;
+  onClose: () => void;
+}
+
+export const CompassView = ({ destination, onClose }: CompassViewProps) => {
+  const { location: currentLocation } = useLocation();
+  const { heading, requestPermission, error } = useDeviceOrientation();
+  const [permissionGranted, setPermissionGranted] = useState(false);
+
+  const handlePermission = async () => {
+    await requestPermission();
+    // We assume permission is granted if the hook is active.
+    // A more robust solution might check the actual permission state.
+    setPermissionGranted(true);
+  };
+
+  const distance = useMemo(() => {
+    if (!currentLocation) return null;
+    // calculateDistance from mapUtils returns km, convert to meters for formatDistance
+    const distanceInKm = calculateDistance(currentLocation, { lat: destination.latitude, lng: destination.longitude });
+    return distanceInKm * 1000;
+  }, [currentLocation, destination]);
+
+  const bearing = useMemo(() => {
+    if (!currentLocation) return null;
+    return calculateBearing(currentLocation, { lat: destination.latitude, lng: destination.longitude });
+  }, [currentLocation, destination]);
+
+  const destinationPointerStyle = {
+    transform: `rotate(${bearing - (heading || 0)}deg)`,
+  };
+
+  const compassRingStyle = {
+    transform: `rotate(-${heading || 0}deg)`,
+  };
+
+  if (!permissionGranted) {
+    return (
+      <div className="absolute inset-0 bg-background z-50 flex flex-col items-center justify-center text-center p-4">
+        <h2 className="text-xl font-semibold mb-4">Kompass-Ansicht benötigt Zugriff auf die Gerätesensoren.</h2>
+        <p className="mb-6 text-muted-foreground">Um Ihnen die Richtung zu weisen, benötigen wir Ihre Zustimmung.</p>
+        <Button onClick={handlePermission}>Zugriff erlauben</Button>
+        <Button variant="ghost" onClick={onClose} className="mt-4">
+          Zurück zur Karte
+        </Button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="absolute inset-0 bg-background z-50 flex flex-col items-center justify-center text-center p-4">
+        <h2 className="text-xl font-semibold text-destructive mb-4">Fehler bei der Sensor-Abfrage</h2>
+        <p className="mb-6 text-muted-foreground">{error}</p>
+        <Button onClick={onClose}>Zurück zur Karte</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="absolute inset-0 bg-background z-50 flex flex-col items-center justify-between p-4">
+      <div className="w-full">
+        <Button variant="ghost" size="icon" onClick={onClose} className="absolute top-4 left-4">
+          <ArrowLeft />
+        </Button>
+        <div className="text-center mt-16">
+          <h1 className="text-2xl font-bold">{destination.name}</h1>
+          <p className="text-lg text-muted-foreground">{distance ? formatDistance(distance) : 'Berechne...'}</p>
+        </div>
+      </div>
+
+      <div className="relative w-64 h-64 flex items-center justify-center">
+        {/* User's heading arrow - always points up */}
+        <NavigationArrow className="w-10 h-10 text-primary absolute -top-12" />
+
+        {/* Compass Ring */}
+        <div className="absolute w-full h-full rounded-full border-4 border-foreground transition-transform duration-500 ease-in-out" style={compassRingStyle}>
+          <div className="absolute top-1/2 left-1/2 -mt-2 -ml-2 w-4 h-4 rounded-full bg-primary" />
+          <span className="absolute -top-4 left-1/2 -ml-2 font-bold text-xl">N</span>
+          <span className="absolute -right-4 top-1/2 -mt-3 font-bold text-xl">E</span>
+          <span className="absolute -bottom-4 left-1/2 -ml-2 font-bold text-xl">S</span>
+          <span className="absolute -left-4 top-1/2 -mt-3 font-bold text-xl">W</span>
+        </div>
+
+        {/* Destination Pointer */}
+        {bearing !== null && (
+          <div className="absolute w-full h-full transition-transform duration-500 ease-in-out" style={destinationPointerStyle}>
+            <NavigationArrow className="w-12 h-12 text-accent absolute top-0 left-1/2 -ml-6 transform -rotate-90" />
+          </div>
+        )}
+      </div>
+
+      <div className="h-16" /> {/* Spacer */}
+
+      {/* Debug Info */}
+      <div className="absolute bottom-4 left-4 bg-black bg-opacity-50 text-white p-2 rounded-md text-xs">
+        <p>Heading: {heading?.toFixed(2) ?? 'N/A'}</p>
+        <p>Bearing: {bearing?.toFixed(2) ?? 'N/A'}</p>
+        <p>Distance: {distance?.toFixed(2) ?? 'N/A'} m</p>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/Navigation/TransparentPOIOverlay.tsx
+++ b/client/src/components/Navigation/TransparentPOIOverlay.tsx
@@ -2,19 +2,21 @@ import React from 'react';
 import { POI } from '@/types/navigation';
 import { POI_CATEGORIES } from '@/types/poi-categories';
 import { Button } from '@/components/ui/button';
-import { X, Navigation, Clock, Phone, Globe, Mail, Building, MapPin } from 'lucide-react';
+import { X, Navigation, Clock, Phone, Globe, Mail, Building, MapPin, Compass } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface TransparentPOIOverlayProps {
   poi: POI;
   onNavigate: (poi: POI) => void;
   onClose: () => void;
+  onCompass: (poi: POI) => void;
 }
 
 export const TransparentPOIOverlay: React.FC<TransparentPOIOverlayProps> = ({
   poi,
   onNavigate,
-  onClose
+  onClose,
+  onCompass
 }) => {
   const { t, translateText } = useLanguage();
 
@@ -287,6 +289,14 @@ export const TransparentPOIOverlay: React.FC<TransparentPOIOverlayProps> = ({
               >
                 <Navigation className="w-4 h-4 mr-2" />
                 {t('navigation.navigateHere')}
+              </Button>
+              <Button
+                variant="outline"
+                className="h-12"
+                onClick={() => onCompass(poi)}
+              >
+                <Compass className="w-4 h-4 mr-2" />
+                {t('navigation.compass')}
               </Button>
             </div>
           </div>

--- a/client/src/hooks/useDeviceOrientation.ts
+++ b/client/src/hooks/useDeviceOrientation.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface DeviceOrientation {
+  heading: number | null;
+  error: string | null;
+}
+
+type DeviceOrientationEventiOS = DeviceOrientationEvent & {
+  webkitCompassHeading?: number;
+};
+
+export const useDeviceOrientation = (): {
+  heading: number | null;
+  error: string | null;
+  requestPermission: () => Promise<void>;
+} => {
+  const [orientation, setOrientation] = useState<DeviceOrientation>({
+    heading: null,
+    error: null,
+  });
+
+  const handleOrientation = (event: DeviceOrientationEvent) => {
+    const eventiOS = event as DeviceOrientationEventiOS;
+    let heading: number | null = null;
+
+    if (eventiOS.webkitCompassHeading) {
+      // iOS
+      heading = eventiOS.webkitCompassHeading;
+    } else if (event.alpha !== null) {
+      // Android
+      heading = 360 - event.alpha;
+    }
+
+    setOrientation({ heading, error: null });
+  };
+
+  const requestPermission = useCallback(async () => {
+    // Check if the API exists and if permission needs to be requested.
+    if (typeof (DeviceOrientationEvent as any).requestPermission === 'function') {
+      try {
+        const permissionState = await (DeviceOrientationEvent as any).requestPermission();
+        if (permissionState === 'granted') {
+          window.addEventListener('deviceorientation', handleOrientation);
+        } else {
+          setOrientation({ heading: null, error: 'Permission denied.' });
+        }
+      } catch (err) {
+        setOrientation({ heading: null, error: (err as Error).message });
+      }
+    } else {
+      // For browsers that don't require permission (e.g., older browsers, Android)
+      window.addEventListener('deviceorientation', handleOrientation);
+    }
+  }, []);
+
+  useEffect(() => {
+    // This effect only cleans up the event listener.
+    // The listener is added after permission is granted.
+    return () => {
+      window.removeEventListener('deviceorientation', handleOrientation);
+    };
+  }, []);
+
+  return { ...orientation, requestPermission };
+};

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -442,7 +442,8 @@ export const translations = {
       next: 'Next',
       speed: 'Speed',
       avg: 'Avg',
-      navigateHere: 'Navigate Here'
+      navigateHere: 'Navigate Here',
+      compass: 'Compass'
     },
     categories: {
       'campsites': 'Campsites',
@@ -562,7 +563,8 @@ export const translations = {
       turnRightOn: 'Rechts abbiegen auf',
       continueOn: 'Weiter auf',
       end: 'Beenden',
-      navigateHere: 'Hier navigieren'
+      navigateHere: 'Hier navigieren',
+      compass: 'Kompass'
     },
     categories: {
       'campsites': 'Campingplätze',
@@ -688,7 +690,8 @@ export const translations = {
       filter: 'Filtrer',
       map: 'Carte',
       navigate: 'Navigation',
-      settings: 'Paramètres'
+      settings: 'Paramètres',
+      compass: 'Boussole'
     },
     categories: {
       'campsites': 'Campings',
@@ -770,7 +773,8 @@ export const translations = {
       filter: 'Filter',
       map: 'Kaart',
       navigate: 'Navigatie',
-      settings: 'Instellingen'
+      settings: 'Instellingen',
+      compass: 'Kompas'
     },
     categories: {
       'campsites': 'Campings',
@@ -847,7 +851,8 @@ export const translations = {
       filter: 'Filtro',
       map: 'Mappa',
       navigation: 'Navigazione',
-      settings: 'Impostazioni'
+      settings: 'Impostazioni',
+      compass: 'Bussola'
     },
     categories: {
       'campsites': 'Campeggi',
@@ -912,7 +917,8 @@ export const translations = {
       filter: 'Filtro',
       map: 'Mapa',
       navigation: 'Navegación',
-      settings: 'Ajustes'
+      settings: 'Ajustes',
+      compass: 'Brújula'
     },
     categories: {
       'campsites': 'Campings',

--- a/client/src/pages/Navigation.tsx
+++ b/client/src/pages/Navigation.tsx
@@ -32,6 +32,7 @@ import { POILocalizationDebugger } from '@/components/Navigation/POILocalization
 import { POILocalizationTestPanel } from '@/components/Navigation/POILocalizationTestPanel';
 import { VoiceControlPanel } from '@/components/Navigation/VoiceControlPanel';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { CompassView } from '@/components/Navigation/CompassView';
 // Removed SmartBottomDrawer - POIs show directly on map
 import { TopBar } from '@/components/Navigation/TopBar'; // Assuming TopBar is imported for the new structure
 import MobileMemoryMonitor from '@/components/UI/MobileMemoryMonitor'; // Assuming MobileMemoryMonitor is available
@@ -100,6 +101,7 @@ export default function Navigation() {
   // New state for POI Dialog visibility
   const [showPOIDialog, setShowPOIDialog] = useState(false);
   const [showPOIOverlay, setShowPOIOverlay] = useState(false);
+  const [isCompassViewActive, setCompassViewActive] = useState(false);
 
   // Voice control state
   const [voiceEnabled, setVoiceEnabled] = useState(true);
@@ -892,6 +894,15 @@ export default function Navigation() {
     setShowPOIDialog(false);
   }, []);
 
+  const handleOpenCompass = useCallback(() => {
+    if (selectedPOI) {
+      setCompassViewActive(true);
+      // Close other overlays when switching to compass view
+      setShowPOIOverlay(false);
+      setShowPOIDialog(false);
+    }
+  }, [selectedPOI]);
+
   const handleCategoryFilter = useCallback((category: string) => {
     console.log('🔍 CATEGORY FILTER DEBUG: ==========================================');
     console.log('🔍 CATEGORY FILTER DEBUG: handleCategoryFilter called with:', category);
@@ -1442,12 +1453,21 @@ export default function Navigation() {
           />
 
 
+          {/* Compass View - Overlays everything when active */}
+          {isCompassViewActive && selectedPOI && (
+            <CompassView
+              destination={selectedPOI}
+              onClose={() => setCompassViewActive(false)}
+            />
+          )}
+
           {/* POI Info Overlay - Positioned below button rows */}
           {showPOIOverlay && selectedPOI && (
             <TransparentPOIOverlay
               poi={selectedPOI}
               onNavigate={handleNavigateToPOI}
               onClose={handleClosePOI}
+              onCompass={handleOpenCompass}
             />
           )}
 
@@ -1458,6 +1478,7 @@ export default function Navigation() {
               isOpen={showPOIDialog}
               onClose={handleClosePOI}
               onNavigate={handleNavigateToPOI}
+              onCompass={handleOpenCompass}
             />
           )}
 


### PR DESCRIPTION
This commit introduces a new 'Compass View' feature that allows users to see the direct line-of-sight direction and distance to a selected Point of Interest (POI).

Key changes include:
- A new `CompassView.tsx` component that renders the compass UI, including the user's heading and a pointer towards the destination.
- A `useDeviceOrientation.ts` hook to abstract the logic for obtaining the device's compass heading, handling permissions and cross-browser differences.
- The POI information overlay has been updated with a 'Compass' button to activate the new view.
- The main `Navigation.tsx` page now manages the state to display the `CompassView` as an overlay.
- The `mapUtils.ts` library was updated to use the robust `turf.js` library for bearing calculations.
- Internationalization support for the new UI elements was added for all supported languages.