### PR TITLE
fix(server): Correct production static asset path to 'dist'

### DIFF
--- a/client/src/components/Navigation/CompassView.tsx
+++ b/client/src/components/Navigation/CompassView.tsx
@@ -83,7 +83,7 @@ export const CompassView = ({ destination, onClose }: CompassViewProps) => {
       <div className="relative w-64 h-64 flex items-center justify-center">
         {/* User's heading arrow - always points up */}
         <Navigation className="w-10 h-10 text-primary absolute -top-12" />
-        
+
         {/* Compass Ring */}
         <div className="absolute w-full h-full rounded-full border-4 border-foreground transition-transform duration-500 ease-in-out" style={compassRingStyle}>
           <div className="absolute top-1/2 left-1/2 -mt-2 -ml-2 w-4 h-4 rounded-full bg-primary" />

--- a/server/index.ts
+++ b/server/index.ts
@@ -161,7 +161,7 @@ app.use((req, res, next) => {
       console.log('📦 Setting up production static serving...');
       
       // Custom static file serving with correct build path
-      const distPath = path.resolve(process.cwd(), "dist/client");
+      const distPath = path.resolve(process.cwd(), "dist");
       
       if (!fs.existsSync(distPath)) {
         console.error(`❌ Warning: Build directory not found at ${distPath}. Run 'npm run build' first.`);


### PR DESCRIPTION
Updates the path for serving static frontend assets to "dist". This corrects a previous fix and aligns the Express server with the Vite build output directory, which resolves the 404 errors in the production deployment.