### PR TITLE
fix(server): Use robust __dirname-based path for static assets

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -67,6 +67,10 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import path from "path";
 import fs from "fs";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Environment validation and info
 const envValidation = validateProductionEnvironment();
@@ -161,7 +165,7 @@ app.use((req, res, next) => {
       console.log('📦 Setting up production static serving...');
       
       // Custom static file serving with correct build path
-      const distPath = path.resolve(process.cwd(), "dist");
+      const distPath = path.resolve(__dirname, "../");
       
       if (!fs.existsSync(distPath)) {
         console.error(`❌ Warning: Build directory not found at ${distPath}. Run 'npm run build' first.`);


### PR DESCRIPTION
Updates the static path calculation in server/index.ts to use a __dirname-based relative path instead of a process.cwd()-based path.

This is more robust and correctly locates the 'dist' folder containing the frontend assets when the server is run from within the 'dist/server' directory. This change ensures the server can find and serve the client-side application in a production build.