### PR TITLE
feat: Implement dynamic network overlay for Zuhause and Kamperland

### DIFF
--- a/client/src/components/Map/MapContainer.tsx
+++ b/client/src/components/Map/MapContainer.tsx
@@ -22,7 +22,7 @@ Icon.Default.mergeOptions({
 // Helper for creating div icons (assuming divIcon is imported from leaflet or a custom hook)
 // If divIcon is not available globally, it needs to be imported. Assuming it's imported from leaflet.
 import { divIcon } from 'leaflet';
-import { NetworkOverlay } from './NetworkOverlay';
+import { NetworkOverlay, NetworkOverlayData } from './NetworkOverlay';
 
 
 interface MapContainerProps {
@@ -41,6 +41,7 @@ interface MapContainerProps {
   mapStyle: 'outdoors' | 'satellite' | 'streets' | 'navigation';
   destinationMarker?: { lat: number; lng: number } | null;
   showNetworkOverlay?: boolean;
+  networkOverlayData?: NetworkOverlayData | null;
   children?: React.ReactNode;
   rotation?: number;
   onRotate?: (rotation: number) => void;
@@ -195,6 +196,7 @@ export const MapContainer: React.FC<MapContainerProps> = ({
   mapStyle,
   destinationMarker,
   showNetworkOverlay = false,
+  networkOverlayData = null,
   children,
   rotation = 0,
   onRotate,
@@ -443,7 +445,7 @@ export const MapContainer: React.FC<MapContainerProps> = ({
         ))}
 
         {/* Network overlay - show routing network */}
-        <NetworkOverlay visible={showNetworkOverlay} />
+        <NetworkOverlay visible={showNetworkOverlay} data={networkOverlayData} />
 
         {/* Glassmorphism route line */}
         {route && <RoutePolyline route={route} />}

--- a/client/src/components/Map/NetworkOverlay.tsx
+++ b/client/src/components/Map/NetworkOverlay.tsx
@@ -26,71 +26,31 @@ interface NetworkOverlayData {
   };
 }
 
-interface NetworkOverlayProps {
-  visible: boolean;
+export interface NetworkOverlayData {
+  nodes: NetworkNode[];
+  edges: NetworkEdge[];
+  stats: {
+    totalNodes: number;
+    totalEdges: number;
+    components: number;
+    coverage: string;
+  };
 }
 
-export const NetworkOverlay: React.FC<NetworkOverlayProps> = ({ visible }) => {
-  const [networkData, setNetworkData] = useState<NetworkOverlayData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+interface NetworkOverlayProps {
+  visible: boolean;
+  data: NetworkOverlayData | null;
+}
 
-  useEffect(() => {
-    if (visible && !networkData) {
-      loadNetworkData();
-    }
-  }, [visible, networkData]);
-
-  const loadNetworkData = async () => {
-    setLoading(true);
-    setError(null);
-    
-    try {
-      console.log('🗺️ NETWORK OVERLAY: Loading network data...');
-      const response = await fetch('/api/network-overlay');
-      
-      if (!response.ok) {
-        throw new Error(`Network overlay request failed: ${response.status}`);
-      }
-      
-      const data: NetworkOverlayData = await response.json();
-      console.log('✅ NETWORK OVERLAY: Raw API response:', data);
-      
-      if (!data.nodes || !data.edges) {
-        throw new Error('Invalid network data structure');
-      }
-      
-      setNetworkData(data);
-      console.log('✅ NETWORK OVERLAY: Loaded', {
-        nodes: data.nodes.length,
-        edges: data.edges.length,
-        components: data.stats.components
-      });
-      
-    } catch (err) {
-      console.error('❌ NETWORK OVERLAY: Load failed:', err);
-      setError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  if (!visible) {
+export const NetworkOverlay: React.FC<NetworkOverlayProps> = ({ visible, data }) => {
+  if (!visible || !data) {
     return null;
-  }
-
-  if (loading) {
-    return null; // Loading silently
-  }
-
-  if (error || !networkData) {
-    return null; // Failed silently
   }
 
   return (
     <>
       {/* Render network edges (roads/paths) */}
-      {networkData.edges.map(edge => (
+      {data.edges.map(edge => (
         <Polyline
           key={edge.id}
           positions={edge.coordinates.map(coord => [coord[1], coord[0]])} // Convert [lng,lat] to [lat,lng] for Leaflet
@@ -114,7 +74,7 @@ export const NetworkOverlay: React.FC<NetworkOverlayProps> = ({ visible }) => {
       ))}
 
       {/* Render network nodes */}
-      {networkData.nodes.map(node => (
+      {data.nodes.map(node => (
         <CircleMarker
           key={node.id}
           center={[node.coordinates[1], node.coordinates[0]]} // Convert [lng,lat] to [lat,lng] for Leaflet

--- a/client/src/components/Navigation/EnhancedMapControls.tsx
+++ b/client/src/components/Navigation/EnhancedMapControls.tsx
@@ -21,6 +21,7 @@ interface EnhancedMapControlsProps {
   onToggleCompass: () => void;
   showNetworkOverlay: boolean;
   onToggleNetworkOverlay: () => void;
+  isNetworkOverlayLoading?: boolean;
 }
 
 const mapStyleConfig = {
@@ -51,7 +52,8 @@ export const EnhancedMapControls: React.FC<EnhancedMapControlsProps> = ({
   compassMode,
   onToggleCompass,
   showNetworkOverlay,
-  onToggleNetworkOverlay
+  onToggleNetworkOverlay,
+  isNetworkOverlayLoading
 }) => {
   const [showVoicePanel, setShowVoicePanel] = useState(false);
   const mapStyleOptions = Object.entries(mapStyleConfig) as [keyof typeof mapStyleConfig, typeof mapStyleConfig[keyof typeof mapStyleConfig]][];
@@ -183,7 +185,11 @@ export const EnhancedMapControls: React.FC<EnhancedMapControlsProps> = ({
         {/* Network Overlay Toggle */}
         {renderControlButton(
           onToggleNetworkOverlay,
-          <Layers className="w-5 h-5 text-white" />,
+          isNetworkOverlayLoading ? (
+            <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+          ) : (
+            <Layers className="w-5 h-5 text-white" />
+          ),
           showNetworkOverlay ? 'Netzwerk-Overlay ausblenden' : 'Netzwerk-Overlay anzeigen',
           showNetworkOverlay
         )}

--- a/client/src/hooks/useNetworkOverlay.ts
+++ b/client/src/hooks/useNetworkOverlay.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSiteManager } from '@/lib/siteManager';
+import { Site } from '@/types/navigation';
+
+// Define the structure of the network overlay data
+interface NetworkOverlayData {
+  nodes: Array<{
+    id: string;
+    coordinates: [number, number];
+    connectionCount: number;
+    type: 'isolated' | 'endpoint' | 'junction';
+  }>;
+  edges: Array<{
+    id:string;
+    coordinates: Array<[number, number]>;
+    pathType: string;
+    distance: number;
+  }>;
+  stats: {
+    totalNodes: number;
+    totalEdges: number;
+    components: number;
+    coverage: string;
+  };
+}
+
+// Async function to fetch the network overlay data
+async function fetchNetworkOverlay(site: Site): Promise<NetworkOverlayData> {
+  const response = await fetch(`/api/network-overlay?site=${site}`);
+  if (!response.ok) {
+    throw new Error('Network response was not ok');
+  }
+  const data = await response.json();
+  return data.data;
+}
+
+// Custom hook to use the network overlay data
+export const useNetworkOverlay = (enabled: boolean) => {
+  const { config } = useSiteManager();
+  const site = config.site;
+
+  return useQuery<NetworkOverlayData, Error>({
+    queryKey: ['networkOverlay', site],
+    queryFn: () => fetchNetworkOverlay(site),
+    enabled: enabled, // Only fetch when the overlay is shown
+  });
+};

--- a/client/src/lib/siteManager.ts
+++ b/client/src/lib/siteManager.ts
@@ -79,6 +79,7 @@ class SiteManagerClass {
    * Change the current site and notify all components
    */
   setSite(newSite: Site): void {
+    console.log(`🎯 SITE MANAGER: setSite called with ${newSite}. Current site is ${this.currentSite}`);
     if (newSite === this.currentSite) {
       console.log(`🎯 SITE MANAGER: Site already set to "${newSite}", no change needed`);
       return;

--- a/client/src/pages/Navigation.tsx
+++ b/client/src/pages/Navigation.tsx
@@ -17,6 +17,7 @@ import { useRouting } from '@/hooks/useRouting';
 import { useWeather } from '@/hooks/useWeather';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useNavigationTracking } from '@/hooks/useNavigationTracking';
+import { useNetworkOverlay } from '@/hooks/useNetworkOverlay';
 import { useSiteManager } from '@/lib/siteManager';
 import { mobileLogger } from '@/utils/mobileLogger';
 import { POI, RouteResponse, TestSite, TEST_SITES, Coordinates, Site } from '@/types/navigation';
@@ -78,6 +79,7 @@ export default function Navigation() {
 
   // Network overlay state
   const [showNetworkOverlay, setShowNetworkOverlay] = useState(false);
+  const { data: networkOverlayData, isLoading: isNetworkOverlayLoading } = useNetworkOverlay(showNetworkOverlay);
 
   // Drawer height state
   const [drawerHeight, setDrawerHeight] = useState<'peek' | 'half' | 'full'>('half');
@@ -966,10 +968,11 @@ export default function Navigation() {
   }, [currentSite, setSite]); // Added setSite to dependencies
 
   const handleSiteChange = useCallback((site: Site) => {
-    console.log(`🔄 Navigation: Site change requested - ${currentSite} -> ${site}`);
+    console.log(`🔄 Navigation: Site change requested - ${config.site} -> ${site}`);
 
     // Use SiteManager setSite function (already extracted at component top-level)
     setSite(site);
+    console.log(`🔄 Navigation: setSite called with ${site}`);
 
     // Clear navigation state when changing sites
     setSelectedPOI(null);
@@ -993,7 +996,7 @@ export default function Navigation() {
       title: t('alerts.siteChanged'),
       description: `${t('alerts.siteSwitched')} ${normalizePoiString(TEST_SITES.find(s => s.id === site)?.name) || site}`,
     });
-  }, [toast, currentSite, t, setSite]);
+  }, [toast, t, setSite]);
 
   const handleClearPOIs = useCallback(() => {
     setSearchQuery('');
@@ -1401,6 +1404,7 @@ export default function Navigation() {
                 mapStyle={mapStyle}
                 destinationMarker={destinationMarker}
                 showNetworkOverlay={showNetworkOverlay}
+                networkOverlayData={networkOverlayData}
                 rotation={mapRotation}
                 onRotate={handleRotate}
                 onRotateStart={handleRotateStart}
@@ -1466,6 +1470,7 @@ export default function Navigation() {
             }}
             showNetworkOverlay={showNetworkOverlay}
             onToggleNetworkOverlay={() => setShowNetworkOverlay(!showNetworkOverlay)}
+            isNetworkOverlayLoading={isNetworkOverlayLoading}
           />
 
 

--- a/server/routes/networkOverlay.ts
+++ b/server/routes/networkOverlay.ts
@@ -25,11 +25,14 @@ interface NetworkOverlayData {
 }
 
 // Generate network overlay data from GeoJSON
-function generateNetworkOverlay(): NetworkOverlayData {
-  console.log('🗺️ NETWORK OVERLAY: Generating visualization data...');
+function generateNetworkOverlay(site: 'kamperland' | 'zuhause' = 'zuhause'): NetworkOverlayData {
+  console.log(`🗺️ NETWORK OVERLAY: Generating visualization data for site: ${site}`);
   
   try {
-    const geojsonPath = './server/data/roompot_routing_network.geojson';
+    const filename = site === 'kamperland' ? 'roompot_routing_network.geojson' : 'zuhause_routing_network.geojson';
+    const geojsonPath = `./server/data/${filename}`;
+    console.log(`🗺️ NETWORK OVERLAY: Loading data from ${geojsonPath}`);
+
     const geojsonData = JSON.parse(readFileSync(geojsonPath, 'utf-8'));
     
     const nodeMap = new Map();
@@ -174,8 +177,9 @@ function getComponentSize(startNodeId: string, nodeMap: Map<string, any>, visite
 // API endpoint
 router.get('/', (req: Request, res: Response) => {
   try {
-    console.log('🗺️ Network overlay data requested');
-    const overlayData = generateNetworkOverlay();
+    const site = req.query.site === 'kamperland' ? 'kamperland' : 'zuhause';
+    console.log(`🗺️ Network overlay data requested for site: ${site}`);
+    const overlayData = generateNetworkOverlay(site);
     
     res.json({
       success: true,


### PR DESCRIPTION
This commit introduces a dynamic network overlay feature that displays the local road network for both the "Zuhause" and "Kamperland" locations.

Key changes include:
- Refactored the `/api/network-overlay` endpoint to accept a `site` query parameter, allowing it to serve the correct GeoJSON file based on the selected location.
- Created a new `useNetworkOverlay` React hook to fetch and manage the network overlay data from the server, using the current site from the `SiteManager`.
- Updated the `NetworkOverlay` component to be a presentational component that receives data via props, removing its internal data-fetching logic.
- Integrated the new hook into the `Navigation` page to fetch the data and pass it to the `MapContainer`.
- Added a loading indicator to the network overlay toggle button to provide feedback to the user while the data is being fetched.