### PR TITLE
Fix: Behebung einer Race Condition in der Navigations-Engine

### DIFF
--- a/client/src/pages/Navigation.tsx
+++ b/client/src/pages/Navigation.tsx
@@ -1248,7 +1248,7 @@ export default function Navigation() {
 
   // Navigation tracking - Initialize route tracker when navigation starts
   useEffect(() => {
-    if (isNavigating && currentRoute && trackingPosition) {
+    if (isNavigating && currentRoute) {
       console.log('Initializing route tracker for navigation');
 
       routeTrackerRef.current = new RouteTracker(
@@ -1305,6 +1305,7 @@ export default function Navigation() {
       // Set initial instruction
       if (currentRoute.instructions.length > 0) {
         setCurrentInstruction(currentRoute.instructions[0].instruction);
+        setCurrentManeuverType(currentRoute.instructions[0].maneuverType);
         setNextDistance(currentRoute.instructions[0].distance);
       }
     }
@@ -1315,7 +1316,7 @@ export default function Navigation() {
         routeTrackerRef.current = null;
       }
     };
-  }, [isNavigating, currentRoute, voiceEnabled, handleEndNavigation]);
+  }, [isNavigating, currentRoute, voiceEnabled, handleEndNavigation, handleReroute]);
 
   // Live position tracking during navigation
   useEffect(() => {


### PR DESCRIPTION
Diese Änderung behebt eine Race Condition, die verhinderte, dass die dynamische Navigation und das Re-Routing korrekt funktionierten.

Das Problem bestand darin, dass die Initialisierung des `RouteTracker` von einer verfügbaren GPS-Position (`trackingPosition`) abhing. Da die Routenberechnung oft schneller war als der Erhalt der ersten GPS-Position, wurde der `RouteTracker` nicht initialisiert, was die gesamte dynamische Aktualisierungslogik blockierte.

Die Korrektur umfasst:
- Entfernung der Abhängigkeit von `trackingPosition` aus der Initialisierungsbedingung des `RouteTracker`. Der Tracker wird nun initialisiert, sobald die Route verfügbar ist.
- Sicherstellung, dass der anfängliche Manöver-Typ korrekt gesetzt wird.
- Aktualisierung der `useEffect`-Abhängigkeitsliste, um `handleReroute` einzuschließen und die Stabilität des Callbacks zu gewährleisten.

Zusätzlich zu dieser Kernkorrektur wurden die vorherigen Änderungen beibehalten, die das dynamische Update der UI-Komponenten und die Re-Routing-Logik an sich implementieren.