### PR TITLE
fix: Translate hardcoded voice announcements to German

### DIFF
--- a/client/src/lib/voiceGuide.ts
+++ b/client/src/lib/voiceGuide.ts
@@ -316,15 +316,15 @@ export class VoiceGuide {
   }
 
   announceOffRoute() {
-    this.speak('You are off the planned route. Recalculating...', 'high');
+    this.speak('Sie haben die Route verlassen. Neue Route wird berechnet...', 'high');
   }
 
   announceDestinationReached() {
-    this.speak('You have arrived at your destination', 'high');
+    this.speak('Sie haben Ihr Ziel erreicht', 'high');
   }
 
   announceRerouting() {
-    this.speak('Route recalculated', 'high');
+    this.speak('Route neu berechnet', 'high');
   }
 
   // Test voice functionality
@@ -336,7 +336,7 @@ export class VoiceGuide {
       }
 
       try {
-        const utterance = new SpeechSynthesisUtterance('Voice test successful');
+        const utterance = new SpeechSynthesisUtterance('Stimmtest erfolgreich');
         utterance.volume = 1;
         utterance.rate = 0.8;
         


### PR DESCRIPTION
This commit resolves an issue where event-based voice announcements were in English while turn-by-turn directions were in German.

The `voiceGuide.ts` service contained several hardcoded English phrases for events such as going off-route, rerouting, and arriving at the destination. These have been translated to their German equivalents to ensure a consistent and fully German-language user experience.

- 'You are off the planned route. Recalculating...' is now 'Sie haben die Route verlassen. Neue Route wird berechnet...'
- 'You have arrived at your destination' is now 'Sie haben Ihr Ziel erreicht'
- 'Route recalculated' is now 'Route neu berechnet'