### PR TITLE
Fix a startup crash caused by unsafe access to localStorage.

### DIFF
--- a/client/src/hooks/useLocation.ts
+++ b/client/src/hooks/useLocation.ts
@@ -13,9 +13,14 @@ export const useLocation = (props?: UseLocationProps) => {
     default: { lat: 51.5896335, lng: 3.7216451 } // Exactly at Starting Point POI on road network
   };
 
-  const [currentSite, setCurrentSite] = useState<string>(
-    localStorage.getItem('selected-site') || 'kamperland'
-  );
+  const [currentSite, setCurrentSite] = useState<string>(() => {
+    try {
+      return localStorage.getItem('selected-site') || 'kamperland';
+    } catch (error) {
+      console.warn('Failed to access localStorage. Defaulting to kamperland.', error);
+      return 'kamperland';
+    }
+  });
   const [currentPosition, setCurrentPosition] = useState<Coordinates>(
     mockCoordinates[currentSite] || mockCoordinates.default
   );


### PR DESCRIPTION
The application was crashing on startup in environments where localStorage is not available or is disabled (e.g., private browsing mode). This was caused by a direct call to `localStorage.getItem` in the `useState` initializer of the `useLocation` hook.

This change wraps the `localStorage.getItem` call in a `try...catch` block. If an error is thrown, it is caught, a warning is logged, and the application falls back to a default value. This prevents the unhandled exception and allows the app to start correctly.