### PR TITLE
feat: Refactor navigation panels and fix UI

### DIFF
--- a/client/src/components/Navigation/BottomSummaryPanel.tsx
+++ b/client/src/components/Navigation/BottomSummaryPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Square } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { coerceMeters, coerceSeconds, formatDistance, formatDuration } from '@/utils/format';
+import { coerceMeters, coerceSeconds, formatDistance, formatDurationShort, formatETA } from '@/utils/format';
 
 interface BottomSummaryPanelProps {
   timeRemaining: number | string | null;
@@ -24,43 +24,30 @@ export const BottomSummaryPanel: React.FC<BottomSummaryPanelProps> = ({
   const coercedSeconds = coerceSeconds(timeRemaining);
   const coercedMeters = coerceMeters(distanceRemaining);
 
-  const formattedTime = formatDuration(coercedSeconds);
-  const formattedDistance = formatDistance(coercedMeters);
+  const durationText = formatDurationShort(coercedSeconds);
+  const distanceText = formatDistance(coercedMeters);
 
-  const getFormattedETA = () => {
-    if (eta instanceof Date && !isNaN(eta.getTime())) {
-      return eta.toLocaleTimeString('de-DE', {
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-    }
-    if (typeof eta === 'string' && eta) {
-      return eta;
-    }
-    return '—';
-  };
-
-  const formattedETA = getFormattedETA();
+  const etaText = eta instanceof Date ? formatETA(eta) : typeof eta === 'string' ? eta : '–';
 
   if (debug) {
     console.log('BottomSummaryPanel Debug:', {
       inputs: { timeRemaining, distanceRemaining, eta },
       coerced: { coercedSeconds, coercedMeters },
-      formatted: { formattedTime, formattedDistance, formattedETA },
+      formatted: { durationText, distanceText, etaText },
     });
   }
 
   return (
-    <div className="absolute bottom-0 left-0 right-0 z-10 bg-card p-4 rounded-t-lg shadow-lg flex items-center justify-between">
+    <div className="flex items-center justify-between w-full">
       <div className="flex flex-col text-left">
-        <span className="text-2xl font-bold">{formattedTime}</span>
-        <span className="text-muted-foreground">
-          {formattedDistance} • {t('arrival')} {formattedETA}
+        <span className="text-lg font-semibold">{durationText}</span>
+        <span className="text-sm text-muted-foreground">
+          {distanceText} • {t('navigation.eta')} {etaText}
         </span>
       </div>
-      <Button variant="destructive" onClick={onEndNavigation} className="p-4 h-auto">
-        <Square className="w-6 h-6 mr-2" />
-        <span className="font-bold">{t('end_navigation')}</span>
+      <Button variant="destructive" onClick={onEndNavigation} className="p-4 h-auto whitespace-nowrap">
+        <Square className="w-5 h-5 mr-2" />
+        <span className="font-bold text-sm">{t('navigation.endNavigation')}</span>
       </Button>
     </div>
   );

--- a/client/src/components/Navigation/TopManeuverPanel.tsx
+++ b/client/src/components/Navigation/TopManeuverPanel.tsx
@@ -6,12 +6,11 @@ import { coerceMeters, formatDistance } from '@/utils/format';
 interface TopManeuverPanelProps {
   instruction: string;
   distance: number | string | null;
-  distanceToNext?: number | string | null; // Optional fallback
+  distanceToNext?: number | string | null;
   maneuverType?: string;
 }
 
 const ManeuverIcon: React.FC<{ type?: string }> = ({ type }) => {
-  // Simple example, can be expanded with more maneuver types
   switch (type) {
     case 'turn-right':
       return <ArrowRight className="w-8 h-8" />;
@@ -33,25 +32,23 @@ export const TopManeuverPanel: React.FC<TopManeuverPanelProps> = ({
 }) => {
   const { t } = useLanguage();
 
-  // Coerce primary distance. If it's invalid (null), try coercing the fallback.
   let coercedMeters = coerceMeters(distance);
   if (coercedMeters === null) {
     coercedMeters = coerceMeters(distanceToNext);
   }
 
   const formattedDistance = formatDistance(coercedMeters);
-
-  // Manually construct the distance text using translated parts, e.g., "Abbiegen in 100 m"
   const distanceText = `${t('navigation.approaching')} ${formattedDistance}`;
 
   return (
-    <div className="absolute top-0 left-0 right-0 z-10 bg-card p-4 rounded-b-lg shadow-lg flex items-center space-x-4">
+    <div className="flex items-center space-x-4 w-full">
       <div className="flex-shrink-0 text-primary">
         <ManeuverIcon type={maneuverType} />
       </div>
-      <div className="flex flex-col text-left flex-grow">
-        <span className="text-xl font-bold">{instruction}</span>
-        {/* Only show distance if it's valid to avoid showing "in —" */}
+      <div className="flex flex-col text-left flex-grow min-w-0">
+        <span className="text-xl font-bold truncate" title={instruction}>
+          {instruction}
+        </span>
         {coercedMeters !== null && (
           <span className="text-muted-foreground text-lg">{distanceText}</span>
         )}

--- a/client/src/components/Navigation/navigation-panels.css
+++ b/client/src/components/Navigation/navigation-panels.css
@@ -1,0 +1,59 @@
+:root {
+  /* Default height of the top search/header bar. Can be adjusted. */
+  --nav-search-height: 64px;
+  --nav-gap: 8px;
+}
+
+/*
+  This container spans the full screen and uses flexbox to position
+  the top and bottom panels correctly. pointer-events: none allows
+  clicks to pass through to the map below.
+*/
+.nav-panel-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000; /* High enough to be over the map, but can be overridden by modals. */
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; /* Pushes children to top and bottom */
+  align-items: center; /* Center panels horizontally */
+  padding: var(--nav-gap);
+  box-sizing: border-box;
+}
+
+/*
+  Common styles for both top and bottom panels.
+  pointer-events: auto re-enables clicks for the panel itself.
+*/
+.nav-panel {
+  pointer-events: auto;
+  width: 100%;
+  max-width: 480px;
+  background-color: hsla(var(--card), 0.9); /* Use theme color with some transparency */
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  color: hsl(var(--card-foreground));
+  padding: 12px 16px;
+  border: 1px solid hsla(var(--border), 0.5);
+}
+
+/*
+  Top panel specific margin to account for safe area (e.g., iPhone notch)
+  and the height of the main search bar.
+*/
+.nav-panel-top {
+  margin-top: calc(env(safe-area-inset-top, 0px) + var(--nav-search-height));
+}
+
+/*
+  Bottom panel specific margin to account for safe area (e.g., iPhone home bar).
+*/
+.nav-panel-bottom {
+  margin-bottom: env(safe-area-inset-bottom, 0px);
+}

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -546,6 +546,8 @@ export const translations = {
       offRoute: 'Abseits der Route',
       complete: 'abgeschlossen',
       eta: 'Ankunft',
+      endNavigation: 'Navigation beenden',
+      approaching: 'Abbiegen in',
       next: 'Nächste',
       speed: 'Geschwindigkeit',
       avg: 'Durchschn.',

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -23,7 +23,6 @@ export function coerceMeters(input: DistanceInput): number | null {
     if (unit === 'km') {
       return value * 1000;
     }
-    // Defaults to meters if the unit is 'm' or absent
     return value;
   }
 
@@ -61,7 +60,6 @@ export function coerceSeconds(input: DurationInput): number | null {
     totalSeconds += parseFloat(secMatches[1]);
   }
 
-  // If no units were found, and it's just a number, assume it's seconds.
   if (!hourMatches && !minMatches && !secMatches && /^\d+(\.\d+)?$/.test(cleanedInput)) {
     return parseFloat(cleanedInput);
   }
@@ -71,11 +69,10 @@ export function coerceSeconds(input: DurationInput): number | null {
 
 /**
  * Formats a distance in meters into a human-readable string ("x m" or "y.z km").
- * Per feedback, rounds distances < 1m down to 0m.
  * @param meters The distance in meters.
  * @returns A formatted string, or '—' if the input is invalid.
  */
-export function formatDistance(meters: number | null | undefined): string {
+export function formatDistance(meters: number | null | undefined, locale = 'de-DE'): string {
   if (meters === null || meters === undefined || !isFinite(meters)) {
     return '—';
   }
@@ -87,7 +84,6 @@ export function formatDistance(meters: number | null | undefined): string {
     return `${formatted.replace('.', ',')} km`;
   }
 
-  // For distances under 10m, floor to avoid rounding up (e.g. 0.6m -> 1m)
   if (meters < 10) {
     return `${Math.floor(meters)} m`;
   }
@@ -123,4 +119,44 @@ export function formatDuration(seconds: number | null | undefined): string {
   }
 
   return `${hours} h ${minutes} min`;
+}
+
+/**
+ * Formats a duration in seconds into a short, locale-aware string ("11 Min" or "1 Std 5 Min").
+ * @param seconds The duration in seconds.
+ * @param locale The locale to use for formatting (currently only 'de' is customized).
+ * @returns A formatted duration string.
+ */
+export function formatDurationShort(seconds: number | null | undefined, locale = 'de'): string {
+  if (seconds === null || seconds === undefined || !isFinite(seconds) || seconds < 0) {
+    return '–';
+  }
+
+  const totalMin = Math.round(seconds / 60);
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+
+  if (locale === 'de') {
+    if (h > 0) return `${h} Std${m > 0 ? ` ${m} Min` : ''}`;
+    return `${m} Min`;
+  }
+
+  // Default/English formatting
+  if (h > 0) return `${h}h${m > 0 ? ` ${m}m` : ''}`;
+  return `${m}m`;
+}
+
+/**
+ * Formats a Date object into a localized time string (e.g., "16:56").
+ * @param date The date to format.
+ * @returns A formatted time string or '—' if invalid.
+ */
+export function formatETA(date: Date | null | undefined): string {
+  if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleTimeString('de-DE', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }


### PR DESCRIPTION
This commit comprehensively refactors the navigation UI to improve robustness, fix layout issues, and standardize data handling.

- Creates a central `client/src/utils/format.ts` utility for coercing and formatting distance and time values.
- Creates a new `client/src/components/Navigation/navigation-panels.css` to provide a robust, flexible, and safe-area-aware layout for the top and bottom navigation panels.
- Refactors `TopManeuverPanel` and `BottomSummaryPanel` to be 'bare' components that only handle content display. They now accept raw data props and use the new formatting utilities for internal presentation.
- Overhauls `Navigation.tsx` to act as the single source of truth:
  - Removes all old, local formatting functions.
  - Passes only raw data (numbers, Dates) to the panel components.
  - Implements the new CSS-based layout, wrapping the panels correctly.
  - Hides the `TopBar` during navigation to prevent UI overlap.
  - Corrects i18n keys for proper localization.
  - Moves TTS client initialization into a `useEffect` to prevent repeated re-initializations.

This resolves a series of UI bugs including flickering values, incorrect layouts, obscured panels, and improper translations.