### PR TITLE
fix(routing): Unify walking speed for consistent ETA calculation

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -649,7 +649,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           modeVerb = 'Cycle';
           modeEmoji = '🚴';
         } else {
-          speedMps = 6 * 1000 / 3600; // 6 km/h walking = 1.67 m/s
+          speedMps = 3.6 * 1000 / 3600; // 3.6 km/h walking = 1.0 m/s
           modeVerb = 'Walk';
           modeEmoji = '🚶';
         }


### PR DESCRIPTION
The ETA calculation for walking routes used different speeds depending on whether the local routing engine or the Google Directions API was used. The local engine used a speed of 6 km/h, while the Google fallback used 3.6 km/h. This inconsistency led to different and potentially unrealistic ETAs for the same route.

This change unifies the walking speed to 3.6 km/h for all walking route calculations to ensure consistent and more accurate ETAs, addressing the user's complaint about incorrect ETA values.