### PR TITLE
refactor(lang): Remove console logs from language detection

### DIFF
--- a/client/src/lib/languageDetection.ts
+++ b/client/src/lib/languageDetection.ts
@@ -13,20 +13,8 @@ export const detectUserLanguage = (): SupportedLanguage => {
   const browserLanguage = navigator.language || 'en-US';
   const detectedCode = getLanguageCode(navigator.language);
 
-  console.log('🌐 Language Detection:', {
-    browserLanguage,
-    detectedCode,
-    displayName: SUPPORTED_LANGUAGES[detectedCode as SupportedLanguage] || 'Unknown',
-    allBrowserLanguages: navigator.languages
-  });
-
   // CRITICAL: Only log when language changes or first time
   if (!window.lastDetectedLang || window.lastDetectedLang !== detectedCode) {
-    console.log('🚨 LANGUAGE CHANGE DETECTED:', {
-      previous: window.lastDetectedLang,
-      current: detectedCode,
-      willAffectEnrichment: true
-    });
     window.lastDetectedLang = detectedCode;
   }
 
@@ -40,7 +28,6 @@ export const detectUserLanguage = (): SupportedLanguage => {
   }
 
   // Default to English
-  console.log('Defaulting to English');
   return 'en';
 };
 
@@ -63,5 +50,4 @@ const getLanguageCode = (lang: string): string => {
 
 export const logLanguageDetection = () => {
   const detected = detectUserLanguage();
-  console.log(`🌐 Final language detection: ${detected} (${SUPPORTED_LANGUAGES[detected]})`);
 };


### PR DESCRIPTION
Removes several `console.log` statements from the `detectUserLanguage` and `logLanguageDetection` functions. These logs were repetitive and cluttered the browser console.