### PR TITLE
Fix: Adjust GPS Log Box position to prevent overlap

### DIFF
--- a/client/src/components/Navigation/ExportLogButton.tsx
+++ b/client/src/components/Navigation/ExportLogButton.tsx
@@ -25,7 +25,7 @@ export const ExportLogButton: React.FC = () => {
 
   return (
     <div 
-      className="fixed bottom-4 left-4 bg-black/80 backdrop-blur-md rounded-lg p-3 z-50"
+      className="fixed bottom-24 left-4 bg-black/80 backdrop-blur-md rounded-lg p-3 z-50"
       style={{
         border: '1px solid rgba(255, 255, 255, 0.2)',
         boxShadow: '0 8px 32px rgba(0, 0, 0, 0.3)'


### PR DESCRIPTION
The GPS Log Export box was overlapping with the bottom navigation bar because both were positioned fixed to the bottom of the screen.

This change adjusts the `bottom` positioning of the `ExportLogButton` component to place it directly above the `BottomSummaryPanel`, resolving the UI overlap issue. The new position is calculated based on the height of the navigation bar.